### PR TITLE
Fix the node version warning from github workflow run.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ outputs:
     description: 'Pin on Crust success or not'
 
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Upgrade from node12 to node20 directly to fix the warning raised by github workflow runner.